### PR TITLE
add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3
+
+# set default environments
+ENV DATA_FILE=/data/data.hdf5
+ENV BASE_URL=http://example.org
+ENV NOTIFY=false
+ENV NOTIFY_CONF=/data/notifications.json
+ENV SMTP_HOST=example.org
+ENV SMTP_PORT=587
+ENV SMTP_USER=example
+ENV SMTP_PASS=secret
+ENV SMTP_FROM=foo@example.org
+
+# install python packages
+RUN pip3 install pandas h5py requests tzlocal dash uwsgi
+
+# create data dir
+RUN mkdir /data
+
+# copy git clone into container
+WORKDIR /ti-monitoring
+COPY . .
+
+# switch to non priv user
+RUN chown -R www-data /ti-monitoring /data
+USER www-data
+
+# run webapp on startup
+CMD ["uwsgi", "--socket=[::]:8000", "--protocol=http", "--wsgi=wsgi"]

--- a/README.md
+++ b/README.md
@@ -85,6 +85,27 @@ Soll die Web-App überhaupt nicht genutzt werden, sind folgende Ordner bzw. Date
 * pages
 * app.py
 
+## Docker
+Docker Image erstellen: `docker build --tag ti-monitoring .`
+
+Container starten: `docker container run ti-monitoring`
+
+[Beispiel Compose File](docker-compose.example.yml)
+
+### Environments
+Die Konfiguration erfolgt über Umgebungsvariablen. Folgende Umgebungsvariablen sind verwendbar:
+| Name | Beschreibung | Default |
+|------|--------------|---------|
+| DATA_FILE | Pfad zur Datei, in der die Monitoring-Daten (von cron.py) abgelegt werden | `/data/data.hdf5` |
+| BASE_URL | Basis URL, die in der Website für Links verwendet wird | `http://example.org` |
+| NOTIFY | Sollen Benachrichtigungen versendet werden? | `false` |
+| NOTIFY_CONF | Pfad zur Konfigurationsdatei für die Benachrichtigungen | `/data/notifications.json` |
+| SMTP_HOST | Mail Host | `example.org` |
+| SMTP_PORT | Mail Port | `587` |
+| SMTP_USER | Mail Benutzer | `example` |
+| SMTP_PASS | Mail Passwort | `secret` |
+| SMTP_FROM | Mail Absender | `foo@example.org` |
+
 ---
 **DISCLAIMER**
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,34 @@
+# set COMPOSE_PROJECT_NAME and DATA in .env
+
+services:
+  monitoring:
+    image: ti-monitoring
+    environment:
+      - BASE_URL=https://my.example.org
+    networks:
+      - internal_proxy
+    labels:
+      - deck-chores.cloud.command=python3 cron.py
+      - deck-chores.cloud.interval=5m
+      - deck-chores.cloud.user=www-data
+      # use traefik as proxy
+      - "traefik.enable=true"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-monitoring.rule=Host(`my.example.org`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-monitoring.entrypoints=https"
+      - "traefik.http.services.${COMPOSE_PROJECT_NAME}-monitoring.loadbalancer.server.port=8000"
+    volumes:
+      - data:/data
+    restart: unless-stopped
+
+networks:
+  # network used by traefik
+  internal_proxy:
+    name: internal_proxy
+    external: true
+
+volumes:
+  data:
+    driver_opts:
+      type: "none"
+      o: "bind"
+      device: "${DATA}/data"

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -20,6 +20,14 @@ services:
       - data:/data
     restart: unless-stopped
 
+  cron:
+    image: ghcr.io/funkyfuture/deck-chores:1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    #networks:
+    #  - backend
+    restart: unless-stopped
+
 networks:
   # network used by traefik
   internal_proxy:

--- a/myconfig.py
+++ b/myconfig.py
@@ -1,26 +1,32 @@
+import os
+
+# helper: convert string into boolean
+def str_to_bool(value: str) -> bool:
+    return value.lower() in ("1", "true", "yes", "on")
+
 # URL for API
-url = "https://ti-lage.prod.ccs.gematik.solutions/lageapi/v1/tilage/bu/PU"
+url = 'https://ti-lage.prod.ccs.gematik.solutions/lageapi/v1/tilage/bu/PU'
 
 # path to hdf5 file for saving the availability data 
-file_name = "data.hdf5"
+file_name = os.getenv('DATA_FILE', 'data.hdf5')
 
 # switching email notofications on/off
-notifications = False
+notifications = str_to_bool(os.getenv('NOTIFY', 'False'))
 
 # configuration for notofications
-notifications_config_file = 'notifications.json'
+notifications_config_file = os.getenv('NOTIFY_CONF', 'notifications.json')
 
 # smtp settings for email notifications
 smtp_settings = {
-    'host' : '********',
-    'port' : 587,
-    'user' : '********',
-    'password' : '********',
-    'from' : '********'
+    'host' : os.getenv('SMTP_USER', '********'),
+    'port' : int(os.getenv('SMTP_PORT', '587')),
+    'user' : os.getenv('SMTP_USER', '********'),
+    'password' : os.getenv('SMTP_PASS', '********'),
+    'from' : os.getenv('SMTP_FROM', '********')
 }
 
 # home url for dash app
-home_url = 'https://ti-monitoring.lukas-schmidt-russnak.de'
+home_url = os.getenv('BASE_URL', 'https://ti-monitoring.lukas-schmidt-russnak.de')
 
 # time frame for statistics in web app
 stats_delta_hours = 12

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,3 @@
+from app import server as application
+if __name__ == '__main__':
+    application.run()


### PR DESCRIPTION
Added docker support by adding files:

- `Dockerfile` -> use to build an image of ti-monitoring
- `docker-compose.example.yml` -> use as an example on how to run image via docker compose
- `wsgi.py` -> wrapper for uwsgi which is used to run app.py inside the container

Also I had to modify `myconfig.py` to override configuration by environment variables. Documentation is added onto `README.md`.

Cron (see docker-compose.example.yml for how to run cron) and Webapp are running fine, notify is currently untested. But as I integrated TI Lage monitoring into my monitoring system (Zabbix) I will not continue work. Sorry :( On the other hand, you may find this helpful.

regards
Daniel